### PR TITLE
[Client] feature : 전체 공개 페이지 구현

### DIFF
--- a/client/src/assets/PublicLetters/PublicLetters.module.css
+++ b/client/src/assets/PublicLetters/PublicLetters.module.css
@@ -1,0 +1,86 @@
+.wrapper {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 100px;
+}
+
+/* ✅ 유연한 그리드 + 가운데 정렬 보완 */
+.lettersContainer {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); /* 유동적 열 */
+  gap: 40px;
+  padding: 40px 20px;
+  max-width: 1200px;
+  width: 100%;
+  justify-items: center; /* 아이템 가로 가운데 정렬 */
+}
+
+.letterCard {
+  background-color: #ffffff;
+  border-radius: 20px;
+  padding: 20px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 150px;
+  width: 100%; 
+  max-width: 280px; /* ✅ 카드 너비 고정 */
+}
+
+.title {
+  font-weight: bold;
+  font-size: 20px;
+  margin-bottom: 10px;
+}
+
+.highlight {
+  background-color: #FFF9CF; 
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+
+.date,
+.arrival {
+  font-size: 14px;
+  color: #444;
+  margin: 0;
+}
+
+.author {
+  margin-top: auto;
+  text-align: right;
+  font-size: 13px;
+  color: #666;
+}
+
+.pagination {
+  margin: 20px 0 40px;
+  display: flex;
+  gap: 8px;
+  font-size: 14px;
+  color: #444;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.pageNumber {
+  background-color: transparent;
+  border: none;
+  padding: 6px 10px;
+  cursor: pointer;
+  border-radius: 50%;
+  transition: background-color 0.2s;
+}
+
+.pageNumber:hover {
+  background-color: #eee;
+}
+
+.active {
+  background-color: white;
+  border: 1px solid #ccc;
+  font-weight: bold;
+}

--- a/client/src/components/PublicLetters/PublicLetters.js
+++ b/client/src/components/PublicLetters/PublicLetters.js
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import styles from "../../assets/PublicLetters/PublicLetters.module.css";
+
+const lettersPerPage = 9;
+
+const allLetters = Array.from({ length: 10 }, (_, index) => ({
+  id: index,
+  title: "편지 제목", // 여기에 실제 제목이 들어가도 OK
+  date: "YYYY년 MM월 DD일으로부터",
+  arrival: "DD일만에 도착한 편지",
+  author: "BY. @@",
+}));
+
+const PublicLetters = () => {
+  const [currentPage, setCurrentPage] = useState(1);
+  const totalPages = Math.ceil(allLetters.length / lettersPerPage);
+
+  const indexOfLast = currentPage * lettersPerPage;
+  const indexOfFirst = indexOfLast - lettersPerPage;
+  const currentLetters = allLetters.slice(indexOfFirst, indexOfLast);
+
+  const handlePageClick = (pageNum) => {
+    setCurrentPage(pageNum);
+  };
+
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.lettersContainer}>
+        {currentLetters.map((letter) => (
+          <div key={letter.id} className={styles.letterCard}>
+            <h3 className={styles.title}>
+              ✉️ <span className={styles.highlight}>{letter.title}</span>
+            </h3>
+            <p className={styles.date}>{letter.date}</p>
+            <p className={styles.arrival}>{letter.arrival}</p>
+            <p className={styles.author}>{letter.author}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className={styles.pagination}>
+        {[...Array(totalPages)].map((_, i) => (
+          <button
+            key={i}
+            onClick={() => handlePageClick(i + 1)}
+            className={`${styles.pageNumber} ${
+              currentPage === i + 1 ? styles.active : ""
+            }`}
+          >
+            {i + 1}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default PublicLetters;

--- a/client/src/components/PublicLetters/PublicLetters.js
+++ b/client/src/components/PublicLetters/PublicLetters.js
@@ -38,19 +38,21 @@ const PublicLetters = () => {
         ))}
       </div>
 
-      <div className={styles.pagination}>
-        {[...Array(totalPages)].map((_, i) => (
-          <button
-            key={i}
-            onClick={() => handlePageClick(i + 1)}
-            className={`${styles.pageNumber} ${
-              currentPage === i + 1 ? styles.active : ""
-            }`}
-          >
-            {i + 1}
-          </button>
-        ))}
-      </div>
+      {totalPages > 1 && (
+        <div className={styles.pagination}>
+          {[...Array(totalPages)].map((_, i) => (
+            <button
+              key={i}
+              onClick={() => handlePageClick(i + 1)}
+              className={`${styles.pageNumber} ${
+                currentPage === i + 1 ? styles.active : ""
+              }`}
+            >
+              {i + 1}
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
 };

--- a/client/src/components/app/Router.js
+++ b/client/src/components/app/Router.js
@@ -7,6 +7,7 @@ import JoinPage from "../../pages/JoinPage";
 import LetterView from "../LetterView/LetterView";
 import MainPage from "../../pages/MainPage";
 import MyPage2 from "../MyPage2/MyPage2"
+import PublicLetters from "../PublicLetters/PublicLetters";
 
 const Router = () => {
   return (
@@ -24,6 +25,7 @@ const Router = () => {
       <Route path="/mypage" element={<MyPage />} />
       <Route path="/mypage2" element={<MyPage2 />} />
       <Route path="/view/:id" element={<LetterView />} />
+      <Route path="/public-letters" element={<PublicLetters />} />
     </Routes>
   );
 };


### PR DESCRIPTION
<!-- 🙌 기여해 주셔서 감사합니다. 아래의 내용을 적어, 더 빠르게 검토할 수 있도록 도와주세요. -->

## #️⃣연관된 이슈
#132 

<!-- 🔨 만약 이 PR이 특정 이슈를 해결한다면, "Fixes #이슈번호" 라고 적어주세요. -->
<!-- 👉 특정 이슈를 언급하고 싶다면, "Relates to #이슈번호" 라고 적어주세요. -->
<!-- ❗ 다른 Pull Request가 먼저 병합되어야 한다면, "**Depends on:** #이슈번호" 라고 적어주세요. -->

## 📝작업 내용
전체 공개 페이지의 뼈대를 구현했습니다.
<!-- 📝 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능) -->
![image](https://github.com/user-attachments/assets/234af76f-a443-4d9f-94b3-cef9c9d3bd15)
![image](https://github.com/user-attachments/assets/00abe8bd-5512-4025-b8f1-57785333e093)

편지가 하나 또는 두 개일 경우에도 가운데 정렬을 하도록  노력하였습니다.
하지만 두개만 존재하는 경우에는 예쁘게 정렬이 되지 않는 것 같아 수정이 필요해 보입니다.
페이지네이션의 경우, 페이지가 하나일 때에는 표시되지 않도록 하였습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)

<!-- 🔬 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->


## 논의하고 싶은 부분(선택)
스크롤을 내려서 보는 것과 스크롤을 안 내리고 한 화면에서 보는 것 중에 뭐가 더 나을지 논의하고 싶습니다.

<!-- 💬 논의하고 싶은 부분이 있다면 작성해주세요.-->

## 🫡 참고사항
